### PR TITLE
Add compatibility to pf2e interactive token tooltip.

### DIFF
--- a/scripts/compatibility-scripts/summary.js
+++ b/scripts/compatibility-scripts/summary.js
@@ -1,5 +1,5 @@
 export const toolbeltID = "pf2e-toolbelt";
-import { getWandFromSpell } from "./wands.js";
+import { getWandFromSpell } from "../wands.js";
 /**
  * Function that creates compatibility with pf2e toolbelt's spell summary
  * @param {*} html

--- a/scripts/compatibility-scripts/token-tooltip.js
+++ b/scripts/compatibility-scripts/token-tooltip.js
@@ -1,0 +1,41 @@
+import { getWandFromSpell } from "../wands.js";
+/**
+ * Changes the html of pf2e token tooltip to make it compatible with this module
+ * @param {*} type
+ * @param {*} sidebar
+ * @param {*} hud
+ * @returns
+ */
+export function changeSpellsTokenTooltip(type, sidebar, hud) {
+  if (type !== "spells") return;
+  const { actor } = hud;
+
+  const entries = sidebar.find(".sidebar-content .entry");
+  console.log(entries);
+  for (const entry of entries) {
+    if (entry.dataset.entry === "cantrip" || entry.dataset.entry === "rituals")
+      continue;
+    const spells = entry.querySelectorAll(".spell.item.item-box");
+    console.log(spells);
+    for (const spell of spells) {
+      const entryId = spell.dataset.entryId;
+      const entry = actor.spellcasting.get(entryId);
+      const isWand = entry?.system?.prepared?.value === "wand";
+      const isScroll = entry?.system?.prepared?.value === "scroll";
+      const isModuleEntry = isWand || isScroll;
+      if (isModuleEntry) {
+        if (isWand) {
+          const realSpell = entry.spells.find(
+            (i) => i.id === spell.dataset.itemId
+          );
+          if (getWandFromSpell(realSpell)?.system?.uses.value === 0) {
+            spell.setAttribute("data-expended", "true");
+            spell.classList.add("expended");
+          }
+        }
+        const typeLabel = spell.querySelectorAll(".details .extras .type");
+        typeLabel[0].innerHTML = isWand ? "Wand" : "Scroll";
+      }
+    }
+  }
+}

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -1,11 +1,15 @@
 import { addScrollSettings, updateScrollSpellcastingEntry } from "./scrolls.js";
-import { renderSummaryTypes, toolbeltID } from "./summary.js";
+import {
+  renderSummaryTypes,
+  toolbeltID,
+} from "./compatibility-scripts/summary.js";
 import {
   moduleID,
   addSlotToggleButton,
   spellcastingEntry_cast,
 } from "./utils.js";
 import { updateWandSpellcastingEntry, renderWandEntries } from "./wands.js";
+import { changeSpellsTokenTooltip } from "./compatibility-scripts/token-tooltip.js";
 
 Hooks.once("init", async () => {
   // Add spell types.
@@ -88,4 +92,11 @@ Hooks.on("renderCreatureSheetPF2e", (sheet, [html], sheetData) => {
     renderSummaryTypes(html, actor);
   }
   renderWandEntries(html, actor);
+});
+
+/**
+ * Hook to make it comaptible with PF2e Interactive Token Tooltip
+ */
+Hooks.on("renderHUDSidebar", (type, sidebar, hud) => {
+  changeSpellsTokenTooltip(type, sidebar, hud);
 });

--- a/scripts/wands.js
+++ b/scripts/wands.js
@@ -39,6 +39,7 @@ export function getWandFromSpell(spell) {
  * @param {*} actor
  */
 export function renderWandEntries(html, actor) {
+  console.log($(html));
   const tab = $(html).find(
     ".sheet-body .sheet-content [data-tab=spellcasting] .spellcastingEntry-list"
   );


### PR DESCRIPTION
- Added compatibility with pf2e interactive token tooltip. Wand and scroll spells will now show correctly. Closes #11 